### PR TITLE
Fixed the composer installation issue

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,7 @@
+
 FROM php:8.1-fpm
-WORKDIR .
+
+
 RUN apt-get update && apt-get install -y \
     curl \
     libicu-dev \
@@ -7,11 +9,23 @@ RUN apt-get update && apt-get install -y \
     libzip-dev \
     && docker-php-ext-install -j$(nproc) intl pdo pdo_mysql zip
 
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-COPY . .
-RUN composer install --prefer-dist --no-progress --no-interaction
 
 EXPOSE 8081
-CMD php -S 0.0.0.0:8081 -t public/
+
+
+WORKDIR /var/www/html
+
+#Edited the installation command for composer due to an issue when trying to create an image 
+RUN apt-get update && \
+    apt-get install -y curl && \
+    curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+
+COPY . .
+
+
+CMD ["php", "-S", "0.0.0.0:8081", "-t", "public/"]
+
+
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,9 @@ services:
       - symfony
 
   symfony:
-    build: ./backend
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
     ports:
       - 8081:8081
     volumes:
@@ -20,9 +22,10 @@ services:
       - DATABASE_URL=mysql://root:jardin@mysql:3306/jardin_actuel?serverVersion=8&charset=utf8mb4
     depends_on:
       - mysql
+    command: bash -c "composer install && php -S 0.0.0.0:8081 -t public/"
     networks:
       - symfony
-
+# added the command to install the composer when running multiple containers
   mysql:
     image: mysql:latest
     restart: always
@@ -32,7 +35,6 @@ services:
       - MYSQL_ROOT_PASSWORD=jardin
       - MYSQL_USER=jardin
       - MYSQL_PASSWORD=jardin
-
     volumes:
       - ./data:/docker-entrypoint-initdb.d
       - ./mysql:/var/lib/mysql
@@ -41,9 +43,8 @@ services:
     ports:
       - 3307:3306
 
-      
 networks:
   symfony:
-  
+
 volumes:
   data:


### PR DESCRIPTION
While creating the backend docker image , the issue "failed to solve: process "/bin/sh -c composer install --prefer-dist --no-progress --no-interaction" did not complete successfully: exit code: 127" persists , edited the backend Dockerfile in order to install the composer + php in the right directory and edited the docker-compose.yml in order to execute the command "composer install && php -S 0.0.0.0:8081 -t public/" 