### PR TITLE
Fix docker issues

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,6 @@
 FROM php:8.1-fpm
 WORKDIR .
+ENV COMPOSER_ALLOW_SUPERUSER=1
 RUN apt-get update && apt-get install -y \
     curl \
     libicu-dev \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,6 @@ services:
   mysql:
     image: mysql:latest
     restart: always
-    command: --default-authentication-plugin=mysql_native_password
     environment:
       - MYSQL_DATABASE=jardin_actuel
       - MYSQL_ROOT_PASSWORD=jardin
@@ -41,9 +40,8 @@ services:
     ports:
       - 3307:3306
 
-      
 networks:
   symfony:
-  
+
 volumes:
   data:


### PR DESCRIPTION
With the new versions of the backend and db images, some issues appeared:
- the `COMPOSER_ALLOW_SUPERUSER` has to be set to 1 to fix the backend image
- the `default-authentication-plugin` option is no longer supported in mysql